### PR TITLE
[Bug fix] Keeping the order of the models

### DIFF
--- a/fixture_generator/management/commands/generate_fixture.py
+++ b/fixture_generator/management/commands/generate_fixture.py
@@ -19,8 +19,9 @@ class CircularDependencyError(Exception):
 def linearize_requirements(available_fixtures, fixture, seen=None):
     if seen is None:
         seen = set([fixture])
-    models = set(fixture.models)
     requirements = []
+    models = []
+
     for requirement in fixture.requires:
         app_label, fixture_name = requirement.rsplit(".", 1)
         fixture_func = available_fixtures[(app_label, fixture_name)]
@@ -32,7 +33,9 @@ def linearize_requirements(available_fixtures, fixture, seen=None):
             seen | set([fixture_func])
         )
         requirements.extend([req for req in r if req not in requirements])
-        models.update(m)
+        models.extend([model for model in m if model not in models])
+
+    models.extend([model for model in fixture.models if model not in models])
     requirements.append(fixture)
     return requirements, models
 

--- a/fixture_generator/tests/tests.py
+++ b/fixture_generator/tests/tests.py
@@ -53,7 +53,7 @@ class LinearizeRequirementsTests(TestCase):
     def test_basic(self):
         requirements, models = self.linearize_requirements(test_func_1)
         self.assertEqual(requirements, [test_func_1])
-        self.assertEqual(models, set())
+        self.assertEqual(models, [])
     
     def test_diamond(self):
         requirements, models = self.linearize_requirements(test_func_2)
@@ -81,11 +81,11 @@ class ManagementCommandTests(TestCase):
     
     def test_basic(self):
         output = self.generate_fixture("tests.test_1")
-        self.assertEqual(output, """[{"pk": 1, "model": "tests.author", "fields": {"name": "Tom Clancy"}}, {"pk": 2, "model": "tests.author", "fields": {"name": "Daniel Pinkwater"}}]\n""")
+        self.assertEqual(output, """[{"pk": 1, "model": "tests.author", "fields": {"name": "Tom Clancy"}}, {"pk": 2, "model": "tests.author", "fields": {"name": "Daniel Pinkwater"}}]""")
     
     def test_auth(self):
         # All that we're checking for is that it doesn't hang on this call,
         # which would happen if the auth post syncdb hook goes and prompts the
         # user to create an account.
         output = self.generate_fixture("tests.test_2")
-        self.assertEqual(output, "[]\n")
+        self.assertEqual(output, "[]")


### PR DESCRIPTION
When doing a `manage.py loaddata` with a fixture, if there are model signals captured
it is very likely that the signal handler uses object references that don't exist yet,
raising Exceptions and failing. Therefore we need to keep the order of the models.
