### PR TITLE
Added full path to the database ENGINE setting for sqlite3

### DIFF
--- a/fixture_generator/management/commands/generate_fixture.py
+++ b/fixture_generator/management/commands/generate_fixture.py
@@ -84,7 +84,7 @@ class Command(BaseCommand):
         requirements, models = linearize_requirements(available_fixtures, fixture)
         
         settings.DATABASES[FIXTURE_DATABASE] = {
-            "ENGINE": "sqlite3",
+            "ENGINE": "django.db.backends.sqlite3",
             "NAME": "fixture_gen.db",
         }
         old_routers = router.routers


### PR DESCRIPTION
tl;dr generate_fixture fails without the full path in the ENGINE setting for sqlite3

When running against Django's trunk, this fails. There is an odd error as the cleanup in the finally clause fails when trying to delete a database that doesn't exist. After digging past that the error is coming from the attempted import of the database engine.

First you will get this exception:

```
vagrant@vagrantup:/vagrant/tests$ dj generate_fixture test_arbitrary.test_users
Traceback (most recent call last):
  File "manage.py", line 14, in <module>
    execute_manager(settings)
  File "/home/vagrant/.virtualenvs/arbitrary/lib/python2.6/site-packages/django/core/management/__init__.py", line 438, in execute_manager
    utility.execute()
  File "/home/vagrant/.virtualenvs/arbitrary/lib/python2.6/site-packages/django/core/management/__init__.py", line 361, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/vagrant/.virtualenvs/arbitrary/lib/python2.6/site-packages/django/core/management/base.py", line 191, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/home/vagrant/.virtualenvs/arbitrary/lib/python2.6/site-packages/django/core/management/base.py", line 222, in execute
    output = self.handle(*args, **options)
  File "/home/vagrant/.virtualenvs/arbitrary/lib/python2.6/site-packages/fixture_generator/management/commands/generate_fixture.py", line 104, in handle
    del connections._connections[FIXTURE_DATABASE]
KeyError: '__fixture_gen__'
```

After digging past that, the real issue is:

```
vagrant@vagrantup:/vagrant/tests$ dj generate_fixture test_arbitrary.test_users
Traceback (most recent call last):
  File "manage.py", line 14, in <module>
    execute_manager(settings)
  File "/home/vagrant/.virtualenvs/arbitrary/lib/python2.6/site-packages/django/core/management/__init__.py", line 438, in execute_manager
    utility.execute()
  File "/home/vagrant/.virtualenvs/arbitrary/lib/python2.6/site-packages/django/core/management/__init__.py", line 361, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/home/vagrant/.virtualenvs/arbitrary/lib/python2.6/site-packages/django/core/management/base.py", line 191, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/home/vagrant/.virtualenvs/arbitrary/lib/python2.6/site-packages/django/core/management/base.py", line 222, in execute
    output = self.handle(*args, **options)
  File "/home/vagrant/.virtualenvs/arbitrary/lib/python2.6/site-packages/fixture_generator/management/commands/generate_fixture.py", line 95, in handle
    interactive=False, migrate_all=True)
  File "/home/vagrant/.virtualenvs/arbitrary/lib/python2.6/site-packages/django/core/management/__init__.py", line 148, in call_command
    return klass.execute(*args, **defaults)
  File "/home/vagrant/.virtualenvs/arbitrary/lib/python2.6/site-packages/django/core/management/base.py", line 222, in execute
    output = self.handle(*args, **options)
  File "/home/vagrant/.virtualenvs/arbitrary/lib/python2.6/site-packages/django/core/management/base.py", line 355, in handle
    return self.handle_noargs(**options)
  File "/home/vagrant/.virtualenvs/arbitrary/lib/python2.6/site-packages/south/management/commands/syncdb.py", line 90, in handle_noargs
    syncdb.Command().execute(**options)
  File "/home/vagrant/.virtualenvs/arbitrary/lib/python2.6/site-packages/django/core/management/base.py", line 222, in execute
    output = self.handle(*args, **options)
  File "/home/vagrant/.virtualenvs/arbitrary/lib/python2.6/site-packages/django/core/management/base.py", line 355, in handle
    return self.handle_noargs(**options)
  File "/home/vagrant/.virtualenvs/arbitrary/lib/python2.6/site-packages/django/core/management/commands/syncdb.py", line 55, in handle_noargs
    connection = connections[db]
  File "/home/vagrant/.virtualenvs/arbitrary/lib/python2.6/site-packages/django/db/utils.py", line 81, in __getitem__
    backend = load_backend(db['ENGINE'])
  File "/home/vagrant/.virtualenvs/arbitrary/lib/python2.6/site-packages/django/db/utils.py", line 23, in load_backend
    return import_module('.base', backend_name)
  File "/home/vagrant/.virtualenvs/arbitrary/lib/python2.6/site-packages/django/utils/importlib.py", line 35, in import_module
    __import__(name)
ImportError: No module named base
```
